### PR TITLE
Added `disable_visit_errors` option to Parser

### DIFF
--- a/lib/jmespath.rb
+++ b/lib/jmespath.rb
@@ -23,14 +23,14 @@ module JMESPath
     # @param [Hash] data
     # @return [Mixed,nil] Returns the matched values. Returns `nil` if the
     #   expression does not resolve inside `data`.
-    def search(expression, data)
+    def search(expression, data, runtime_options = {})
       data = case data
         when Hash, Struct then data # check for most common case first
         when Pathname then load_json(data)
         when IO, StringIO then JSON.load(data.read)
         else data
         end
-      Runtime.new.search(expression, data)
+      Runtime.new(runtime_options).search(expression, data)
     end
 
     # @api private

--- a/lib/jmespath/errors.rb
+++ b/lib/jmespath/errors.rb
@@ -3,9 +3,9 @@ module JMESPath
 
     class Error < StandardError; end
 
-    class RuntimeError < Error; end
-
     class SyntaxError < Error; end
+
+    class InvalidValueError < Error; end
 
     class InvalidTypeError < Error; end
 

--- a/lib/jmespath/nodes.rb
+++ b/lib/jmespath/nodes.rb
@@ -35,7 +35,6 @@ module JMESPath
     autoload :ArrayProjection, 'jmespath/nodes/projection'
     autoload :ObjectProjection, 'jmespath/nodes/projection'
     autoload :Slice, 'jmespath/nodes/slice'
-    autoload :NonRaisingSlice, 'jmespath/nodes/slice'
     autoload :Subexpression, 'jmespath/nodes/subexpression'
   end
 end

--- a/lib/jmespath/nodes.rb
+++ b/lib/jmespath/nodes.rb
@@ -35,6 +35,7 @@ module JMESPath
     autoload :ArrayProjection, 'jmespath/nodes/projection'
     autoload :ObjectProjection, 'jmespath/nodes/projection'
     autoload :Slice, 'jmespath/nodes/slice'
+    autoload :NonRaisingSlice, 'jmespath/nodes/slice'
     autoload :Subexpression, 'jmespath/nodes/subexpression'
   end
 end

--- a/lib/jmespath/nodes/function.rb
+++ b/lib/jmespath/nodes/function.rb
@@ -313,7 +313,7 @@ module JMESPath
       def call(args)
         if args.count == 1
           value = args.first
-          String === value ? value : MultiJson.dump(value)
+          String === value ? value : JSON.dump(value)
         else
           return maybe_raise Errors::InvalidArityError, "function to_string() expects one argument"
         end

--- a/lib/jmespath/nodes/function.rb
+++ b/lib/jmespath/nodes/function.rb
@@ -36,7 +36,7 @@ module JMESPath
 
       private
 
-      def error_raise(error_type, message)
+      def maybe_raise(error_type, message)
         unless @disable_visit_errors
           raise error_type, message
         end
@@ -86,12 +86,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          return error_raise Errors::InvalidArityError, "function abs() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function abs() expects one argument"
         end
         if Numeric === value
           value.abs
         else
-          return error_raise Errors::InvalidTypeError, "function abs() expects a number"
+          return maybe_raise Errors::InvalidTypeError, "function abs() expects a number"
         end
       end
     end
@@ -103,18 +103,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          return error_raise Errors::InvalidArityError, "function avg() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function avg() expects one argument"
         end
         if Array === values
           values.inject(0) do |total,n|
             if Numeric === n
               total + n
             else
-              return error_raise Errors::InvalidTypeError, "function avg() expects numeric values"
+              return maybe_raise Errors::InvalidTypeError, "function avg() expects numeric values"
             end
           end / values.size.to_f
         else
-          return error_raise Errors::InvalidTypeError, "function avg() expects a number"
+          return maybe_raise Errors::InvalidTypeError, "function avg() expects a number"
         end
       end
     end
@@ -126,12 +126,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          return error_raise Errors::InvalidArityError, "function ceil() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function ceil() expects one argument"
         end
         if Numeric === value
           value.ceil
         else
-          return error_raise Errors::InvalidTypeError, "function ceil() expects a numeric value"
+          return maybe_raise Errors::InvalidTypeError, "function ceil() expects a numeric value"
         end
       end
     end
@@ -146,10 +146,10 @@ module JMESPath
           if String === haystack || Array === haystack
             haystack.include?(needle)
           else
-            return error_raise Errors::InvalidTypeError, "contains expects 2nd arg to be a list"
+            return maybe_raise Errors::InvalidTypeError, "contains expects 2nd arg to be a list"
           end
         else
-          return error_raise Errors::InvalidArityError, "function contains() expects 2 arguments"
+          return maybe_raise Errors::InvalidArityError, "function contains() expects 2 arguments"
         end
       end
     end
@@ -161,12 +161,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          return error_raise Errors::InvalidArityError, "function floor() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function floor() expects one argument"
         end
         if Numeric === value
           value.floor
         else
-          return error_raise Errors::InvalidTypeError, "function floor() expects a numeric value"
+          return maybe_raise Errors::InvalidTypeError, "function floor() expects a numeric value"
         end
       end
     end
@@ -178,11 +178,11 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          return error_raise Errors::InvalidArityError, "function length() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function length() expects one argument"
         end
         case value
         when Hash, Array, String then value.size
-        else return error_raise Errors::InvalidTypeError, "function length() expects string, array or object"
+        else return maybe_raise Errors::InvalidTypeError, "function length() expects string, array or object"
         end
       end
     end
@@ -194,18 +194,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          return error_raise Errors::InvalidArityError, "function max() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function max() expects one argument"
         end
         if Array === values
           values.inject(values.first) do |max, v|
             if Numeric === v
               v > max ? v : max
             else
-              return error_raise Errors::InvalidTypeError, "function max() expects numeric values"
+              return maybe_raise Errors::InvalidTypeError, "function max() expects numeric values"
             end
           end
         else
-          return error_raise Errors::InvalidTypeError, "function max() expects an array"
+          return maybe_raise Errors::InvalidTypeError, "function max() expects an array"
         end
       end
     end
@@ -217,18 +217,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          return error_raise Errors::InvalidArityError, "function min() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function min() expects one argument"
         end
         if Array === values
           values.inject(values.first) do |min, v|
             if Numeric === v
               v < min ? v : min
             else
-              return error_raise Errors::InvalidTypeError, "function min() expects numeric values"
+              return maybe_raise Errors::InvalidTypeError, "function min() expects numeric values"
             end
           end
         else
-          return error_raise Errors::InvalidTypeError, "function min() expects an array"
+          return maybe_raise Errors::InvalidTypeError, "function min() expects an array"
         end
       end
     end
@@ -242,7 +242,7 @@ module JMESPath
         if args.count == 1
           TYPE_NAMES[get_type(args.first)]
         else
-          return error_raise Errors::InvalidArityError, "function type() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function type() expects one argument"
         end
       end
     end
@@ -260,10 +260,10 @@ module JMESPath
             else raise NotImplementedError
             end
           else
-            return error_raise Errors::InvalidTypeError, "function keys() expects a hash"
+            return maybe_raise Errors::InvalidTypeError, "function keys() expects a hash"
           end
         else
-          return error_raise Errors::InvalidArityError, "function keys() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function keys() expects one argument"
         end
       end
     end
@@ -279,10 +279,10 @@ module JMESPath
           elsif Array === value
             value
           else
-            return error_raise Errors::InvalidTypeError, "function values() expects an array or a hash"
+            return maybe_raise Errors::InvalidTypeError, "function values() expects an array or a hash"
           end
         else
-          return error_raise Errors::InvalidArityError, "function values() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function values() expects one argument"
         end
       end
     end
@@ -295,14 +295,14 @@ module JMESPath
           glue = args[0]
           values = args[1]
           if !(String === glue)
-            return error_raise Errors::InvalidTypeError, "function join() expects the first argument to be a string"
+            return maybe_raise Errors::InvalidTypeError, "function join() expects the first argument to be a string"
           elsif Array === values && values.all? { |v| String === v }
             values.join(glue)
           else
-            return error_raise Errors::InvalidTypeError, "function join() expects values to be an array of strings"
+            return maybe_raise Errors::InvalidTypeError, "function join() expects values to be an array of strings"
           end
         else
-          return error_raise Errors::InvalidArityError, "function join() expects an array of strings"
+          return maybe_raise Errors::InvalidArityError, "function join() expects an array of strings"
         end
       end
     end
@@ -315,7 +315,7 @@ module JMESPath
           value = args.first
           String === value ? value : MultiJson.dump(value)
         else
-          return error_raise Errors::InvalidArityError, "function to_string() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function to_string() expects one argument"
         end
       end
     end
@@ -332,7 +332,7 @@ module JMESPath
             nil
           end
         else
-          return error_raise Errors::InvalidArityError, "function to_number() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function to_number() expects one argument"
         end
       end
     end
@@ -346,11 +346,11 @@ module JMESPath
             if Numeric === n
               sum + n
             else
-              return error_raise Errors::InvalidTypeError, "function sum() expects values to be numeric"
+              return maybe_raise Errors::InvalidTypeError, "function sum() expects values to be numeric"
             end
           end
         else
-          return error_raise Errors::InvalidArityError, "function sum() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function sum() expects one argument"
         end
       end
     end
@@ -362,7 +362,7 @@ module JMESPath
         if args.count > 0
           args.find { |value| !value.nil? }
         else
-          return error_raise Errors::InvalidArityError, "function not_null() expects one or more arguments"
+          return maybe_raise Errors::InvalidArityError, "function not_null() expects one or more arguments"
         end
       end
     end
@@ -382,14 +382,14 @@ module JMESPath
               if (a_type == STRING_TYPE || a_type == NUMBER_TYPE) && a_type == b_type
                 a <=> b
               else
-                return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+                return maybe_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
               end
             end
           else
-            return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+            return maybe_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
           end
         else
-          return error_raise Errors::InvalidArityError, "function sort() expects one argument"
+          return maybe_raise Errors::InvalidArityError, "function sort() expects one argument"
         end
       end
     end
@@ -412,14 +412,14 @@ module JMESPath
               if (a_type == STRING_TYPE || a_type == NUMBER_TYPE) && a_type == b_type
                 a_value <=> b_value
               else
-                return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+                return maybe_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
               end
             end
           else
-            return error_raise Errors::InvalidTypeError, "function sort_by() expects an array and an expression"
+            return maybe_raise Errors::InvalidTypeError, "function sort_by() expects an array and an expression"
           end
         else
-          return error_raise Errors::InvalidArityError, "function sort_by() expects two arguments"
+          return maybe_raise Errors::InvalidArityError, "function sort_by() expects two arguments"
         end
       end
     end
@@ -437,14 +437,14 @@ module JMESPath
               if get_type(value) == NUMBER_TYPE
                 value
               else
-                return error_raise Errors::InvalidTypeError, "function #{mode}() expects values to be an numbers"
+                return maybe_raise Errors::InvalidTypeError, "function #{mode}() expects values to be an numbers"
               end
             end
           else
-            return error_raise Errors::InvalidTypeError, "function #{mode}() expects an array and an expression"
+            return maybe_raise Errors::InvalidTypeError, "function #{mode}() expects an array and an expression"
           end
         else
-          return error_raise Errors::InvalidArityError, "function #{mode}() expects two arguments"
+          return maybe_raise Errors::InvalidArityError, "function #{mode}() expects two arguments"
         end
       end
     end

--- a/lib/jmespath/nodes/function.rb
+++ b/lib/jmespath/nodes/function.rb
@@ -4,13 +4,15 @@ module JMESPath
     class Function < Node
       FUNCTIONS = {}
 
-      def initialize(children)
+      def initialize(children, options = {})
         @children = children
+        @options = options
+        @disable_visit_errors = @options[:disable_visit_errors]
       end
 
-      def self.create(name, children)
+      def self.create(name, children, options = {})
         if (type = FUNCTIONS[name])
-          type.new(children)
+          type.new(children, options)
         else
           raise Errors::UnknownFunctionError, "unknown function #{name}()"
         end
@@ -21,7 +23,7 @@ module JMESPath
       end
 
       def optimize
-        self.class.new(@children.map(&:optimize))
+        self.class.new(@children.map(&:optimize), @options)
       end
 
       class FunctionName
@@ -33,6 +35,12 @@ module JMESPath
       end
 
       private
+
+      def error_raise(error_type, message)
+        unless @disable_visit_errors
+          raise error_type, message
+        end
+      end
 
       def call(args)
         nil
@@ -78,12 +86,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          raise Errors::InvalidArityError, "function abs() expects one argument"
+          return error_raise Errors::InvalidArityError, "function abs() expects one argument"
         end
         if Numeric === value
           value.abs
         else
-          raise Errors::InvalidTypeError, "function abs() expects a number"
+          return error_raise Errors::InvalidTypeError, "function abs() expects a number"
         end
       end
     end
@@ -95,18 +103,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          raise Errors::InvalidArityError, "function avg() expects one argument"
+          return error_raise Errors::InvalidArityError, "function avg() expects one argument"
         end
         if Array === values
           values.inject(0) do |total,n|
             if Numeric === n
               total + n
             else
-              raise Errors::InvalidTypeError, "function avg() expects numeric values"
+              return error_raise Errors::InvalidTypeError, "function avg() expects numeric values"
             end
           end / values.size.to_f
         else
-          raise Errors::InvalidTypeError, "function avg() expects a number"
+          return error_raise Errors::InvalidTypeError, "function avg() expects a number"
         end
       end
     end
@@ -118,12 +126,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          raise Errors::InvalidArityError, "function ceil() expects one argument"
+          return error_raise Errors::InvalidArityError, "function ceil() expects one argument"
         end
         if Numeric === value
           value.ceil
         else
-          raise Errors::InvalidTypeError, "function ceil() expects a numeric value"
+          return error_raise Errors::InvalidTypeError, "function ceil() expects a numeric value"
         end
       end
     end
@@ -138,10 +146,10 @@ module JMESPath
           if String === haystack || Array === haystack
             haystack.include?(needle)
           else
-            raise Errors::InvalidTypeError, "contains expects 2nd arg to be a list"
+            return error_raise Errors::InvalidTypeError, "contains expects 2nd arg to be a list"
           end
         else
-          raise Errors::InvalidArityError, "function contains() expects 2 arguments"
+          return error_raise Errors::InvalidArityError, "function contains() expects 2 arguments"
         end
       end
     end
@@ -153,12 +161,12 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          raise Errors::InvalidArityError, "function floor() expects one argument"
+          return error_raise Errors::InvalidArityError, "function floor() expects one argument"
         end
         if Numeric === value
           value.floor
         else
-          raise Errors::InvalidTypeError, "function floor() expects a numeric value"
+          return error_raise Errors::InvalidTypeError, "function floor() expects a numeric value"
         end
       end
     end
@@ -170,11 +178,11 @@ module JMESPath
         if args.count == 1
           value = args.first
         else
-          raise Errors::InvalidArityError, "function length() expects one argument"
+          return error_raise Errors::InvalidArityError, "function length() expects one argument"
         end
         case value
         when Hash, Array, String then value.size
-        else raise Errors::InvalidTypeError, "function length() expects string, array or object"
+        else return error_raise Errors::InvalidTypeError, "function length() expects string, array or object"
         end
       end
     end
@@ -186,18 +194,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          raise Errors::InvalidArityError, "function max() expects one argument"
+          return error_raise Errors::InvalidArityError, "function max() expects one argument"
         end
         if Array === values
           values.inject(values.first) do |max, v|
             if Numeric === v
               v > max ? v : max
             else
-              raise Errors::InvalidTypeError, "function max() expects numeric values"
+              return error_raise Errors::InvalidTypeError, "function max() expects numeric values"
             end
           end
         else
-          raise Errors::InvalidTypeError, "function max() expects an array"
+          return error_raise Errors::InvalidTypeError, "function max() expects an array"
         end
       end
     end
@@ -209,18 +217,18 @@ module JMESPath
         if args.count == 1
           values = args.first
         else
-          raise Errors::InvalidArityError, "function min() expects one argument"
+          return error_raise Errors::InvalidArityError, "function min() expects one argument"
         end
         if Array === values
           values.inject(values.first) do |min, v|
             if Numeric === v
               v < min ? v : min
             else
-              raise Errors::InvalidTypeError, "function min() expects numeric values"
+              return error_raise Errors::InvalidTypeError, "function min() expects numeric values"
             end
           end
         else
-          raise Errors::InvalidTypeError, "function min() expects an array"
+          return error_raise Errors::InvalidTypeError, "function min() expects an array"
         end
       end
     end
@@ -234,7 +242,7 @@ module JMESPath
         if args.count == 1
           TYPE_NAMES[get_type(args.first)]
         else
-          raise Errors::InvalidArityError, "function type() expects one argument"
+          return error_raise Errors::InvalidArityError, "function type() expects one argument"
         end
       end
     end
@@ -252,10 +260,10 @@ module JMESPath
             else raise NotImplementedError
             end
           else
-            raise Errors::InvalidTypeError, "function keys() expects a hash"
+            return error_raise Errors::InvalidTypeError, "function keys() expects a hash"
           end
         else
-          raise Errors::InvalidArityError, "function keys() expects one argument"
+          return error_raise Errors::InvalidArityError, "function keys() expects one argument"
         end
       end
     end
@@ -271,10 +279,10 @@ module JMESPath
           elsif Array === value
             value
           else
-            raise Errors::InvalidTypeError, "function values() expects an array or a hash"
+            return error_raise Errors::InvalidTypeError, "function values() expects an array or a hash"
           end
         else
-          raise Errors::InvalidArityError, "function values() expects one argument"
+          return error_raise Errors::InvalidArityError, "function values() expects one argument"
         end
       end
     end
@@ -287,14 +295,14 @@ module JMESPath
           glue = args[0]
           values = args[1]
           if !(String === glue)
-            raise Errors::InvalidTypeError, "function join() expects the first argument to be a string"
+            return error_raise Errors::InvalidTypeError, "function join() expects the first argument to be a string"
           elsif Array === values && values.all? { |v| String === v }
             values.join(glue)
           else
-            raise Errors::InvalidTypeError, "function join() expects values to be an array of strings"
+            return error_raise Errors::InvalidTypeError, "function join() expects values to be an array of strings"
           end
         else
-          raise Errors::InvalidArityError, "function join() expects an array of strings"
+          return error_raise Errors::InvalidArityError, "function join() expects an array of strings"
         end
       end
     end
@@ -307,7 +315,7 @@ module JMESPath
           value = args.first
           String === value ? value : MultiJson.dump(value)
         else
-          raise Errors::InvalidArityError, "function to_string() expects one argument"
+          return error_raise Errors::InvalidArityError, "function to_string() expects one argument"
         end
       end
     end
@@ -324,7 +332,7 @@ module JMESPath
             nil
           end
         else
-          raise Errors::InvalidArityError, "function to_number() expects one argument"
+          return error_raise Errors::InvalidArityError, "function to_number() expects one argument"
         end
       end
     end
@@ -338,11 +346,11 @@ module JMESPath
             if Numeric === n
               sum + n
             else
-              raise Errors::InvalidTypeError, "function sum() expects values to be numeric"
+              return error_raise Errors::InvalidTypeError, "function sum() expects values to be numeric"
             end
           end
         else
-          raise Errors::InvalidArityError, "function sum() expects one argument"
+          return error_raise Errors::InvalidArityError, "function sum() expects one argument"
         end
       end
     end
@@ -354,7 +362,7 @@ module JMESPath
         if args.count > 0
           args.find { |value| !value.nil? }
         else
-          raise Errors::InvalidArityError, "function not_null() expects one or more arguments"
+          return error_raise Errors::InvalidArityError, "function not_null() expects one or more arguments"
         end
       end
     end
@@ -374,14 +382,14 @@ module JMESPath
               if (a_type == STRING_TYPE || a_type == NUMBER_TYPE) && a_type == b_type
                 a <=> b
               else
-                raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+                return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
               end
             end
           else
-            raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+            return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
           end
         else
-          raise Errors::InvalidArityError, "function sort() expects one argument"
+          return error_raise Errors::InvalidArityError, "function sort() expects one argument"
         end
       end
     end
@@ -404,14 +412,14 @@ module JMESPath
               if (a_type == STRING_TYPE || a_type == NUMBER_TYPE) && a_type == b_type
                 a_value <=> b_value
               else
-                raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
+                return error_raise Errors::InvalidTypeError, "function sort() expects values to be an array of numbers or integers"
               end
             end
           else
-            raise Errors::InvalidTypeError, "function sort_by() expects an array and an expression"
+            return error_raise Errors::InvalidTypeError, "function sort_by() expects an array and an expression"
           end
         else
-          raise Errors::InvalidArityError, "function sort_by() expects two arguments"
+          return error_raise Errors::InvalidArityError, "function sort_by() expects two arguments"
         end
       end
     end
@@ -429,14 +437,14 @@ module JMESPath
               if get_type(value) == NUMBER_TYPE
                 value
               else
-                raise Errors::InvalidTypeError, "function #{mode}() expects values to be an numbers"
+                return error_raise Errors::InvalidTypeError, "function #{mode}() expects values to be an numbers"
               end
             end
           else
-            raise Errors::InvalidTypeError, "function #{mode}() expects an array and an expression"
+            return error_raise Errors::InvalidTypeError, "function #{mode}() expects an array and an expression"
           end
         else
-          raise Errors::InvalidArityError, "function #{mode}() expects two arguments"
+          return error_raise Errors::InvalidArityError, "function #{mode}() expects two arguments"
         end
       end
     end

--- a/lib/jmespath/nodes/slice.rb
+++ b/lib/jmespath/nodes/slice.rb
@@ -11,6 +11,7 @@ module JMESPath
       def visit(value)
         if String === value || Array === value
           start, stop, step = adjust_slice(value.size, @start, @stop, @step)
+          return unless start && stop && step
           result = []
           if step > 0
             i = start
@@ -45,7 +46,7 @@ module JMESPath
         if step.nil?
           step = 1
         elsif step == 0
-          raise Errors::RuntimeError, 'slice step cannot be 0'
+          return runtime_error('slice step cannot be 0')
         end
 
         if start.nil?
@@ -73,6 +74,16 @@ module JMESPath
         else
           endpoint
         end
+      end
+
+      def runtime_error(message)
+        raise Errors::RuntimeError, message
+      end
+    end
+
+    class NonRaisingSlice < Slice
+      def runtime_error(message)
+        return nil
       end
     end
 

--- a/lib/jmespath/nodes/slice.rb
+++ b/lib/jmespath/nodes/slice.rb
@@ -6,7 +6,7 @@ module JMESPath
         @start = start
         @stop = stop
         @step = step
-        raise Errors::RuntimeError.new('slice step cannot be 0') if @step == 0
+        raise Errors::InvalidValueError.new('slice step cannot be 0') if @step == 0
       end
 
       def visit(value)

--- a/lib/jmespath/nodes/slice.rb
+++ b/lib/jmespath/nodes/slice.rb
@@ -6,6 +6,7 @@ module JMESPath
         @start = start
         @stop = stop
         @step = step
+        raise Errors::RuntimeError.new('slice step cannot be 0') if @step == 0
       end
 
       def visit(value)
@@ -45,8 +46,6 @@ module JMESPath
       def adjust_slice(length, start, stop, step)
         if step.nil?
           step = 1
-        elsif step == 0
-          return runtime_error('slice step cannot be 0')
         end
 
         if start.nil?
@@ -74,16 +73,6 @@ module JMESPath
         else
           endpoint
         end
-      end
-
-      def runtime_error(message)
-        raise Errors::RuntimeError, message
-      end
-    end
-
-    class NonRaisingSlice < Slice
-      def runtime_error(message)
-        return nil
       end
     end
 

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -20,6 +20,7 @@ module JMESPath
     # @option options [Lexer] :lexer
     def initialize(options = {})
       @lexer = options[:lexer] || Lexer.new()
+      @disable_visit_errors = options[:disable_visit_errors]
     end
 
     # @param [String<JMESPath>] expression
@@ -188,7 +189,7 @@ module JMESPath
         end
       end
       stream.next
-      Nodes::Function.create(name, args)
+      Nodes::Function.create(name, args, :disable_visit_errors => @disable_visit_errors)
     end
 
     def led_or(stream, left)
@@ -219,6 +220,8 @@ module JMESPath
         Nodes::Index.new(parts[0])
       elsif pos > 2
         raise Errors::SyntaxError, 'invalid array slice syntax: too many colons'
+      elsif @disable_visit_errors
+        Nodes::NonRaisingSlice.new(*parts)
       else
         Nodes::Slice.new(*parts)
       end

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -220,8 +220,6 @@ module JMESPath
         Nodes::Index.new(parts[0])
       elsif pos > 2
         raise Errors::SyntaxError, 'invalid array slice syntax: too many colons'
-      elsif @disable_visit_errors
-        Nodes::NonRaisingSlice.new(*parts)
       else
         Nodes::Slice.new(*parts)
       end

--- a/lib/jmespath/runtime.rb
+++ b/lib/jmespath/runtime.rb
@@ -49,6 +49,11 @@ module JMESPath
     #   searches, so it's highly recommended if you're using the same expression
     #   multiple times and have not disabled caching. Defaults to `true`.
     #
+    # @option options [Boolean] :disable_visit_errors (false) When `true`,
+    #   no errors will be raised during runtime processing. Parse errors
+    #   will still be raised, but unexpected data sent to visit will
+    #   result in nil being returned.
+    #
     # @option options [Parser] :parser
     #
     def initialize(options = {})
@@ -68,7 +73,7 @@ module JMESPath
     private
 
     def create_parser(options)
-      parser = Parser.new
+      parser = Parser.new(:disable_visit_errors => !!options[:disable_visit_errors])
       unless options[:optimize_expression] == false
         parser = OptimizingParser.new(parser)
       end

--- a/spec/compliance/slice.json
+++ b/spec/compliance/slice.json
@@ -77,7 +77,7 @@
     },
     {
       "expression": "foo[8:2:0]",
-      "error": "runtime"
+      "error": "invalid-value"
     },
     {
       "expression": "foo[8:2:0:1]",

--- a/spec/compliance_spec.rb
+++ b/spec/compliance_spec.rb
@@ -16,7 +16,7 @@ describe 'Compliance' do
               it "the expression #{test_case['expression'].inspect} raises a #{test_case['error']} error" do
 
                 error_class = case test_case['error']
-                  when 'runtime' then JMESPath::Errors::RuntimeError
+                  when 'invalid-value' then JMESPath::Errors::InvalidValueError
                   when 'syntax' then JMESPath::Errors::SyntaxError
                   when 'invalid-type' then JMESPath::Errors::InvalidTypeError
                   when 'invalid-arity' then JMESPath::Errors::InvalidArityError

--- a/spec/compliance_without_errors_spec.rb
+++ b/spec/compliance_without_errors_spec.rb
@@ -14,7 +14,7 @@ describe 'Compliance' do
 
             if test_case['error']
 
-              if %w[invalid-type invalid-arity runtime].include?(test_case['error'])
+              if %w[invalid-type invalid-arity].include?(test_case['error'])
                 it "the expression #{test_case['expression'].inspect} returns nil if disable_visit_errors is true" do
                   
                   result = PARSER.parse(test_case['expression']).visit(scenario['given'])
@@ -24,6 +24,7 @@ describe 'Compliance' do
                 it "the expression #{test_case['expression'].inspect} raises a #{test_case['error']} error when parsing even if disable_visit_errors is true" do
 
                   error_class = case test_case['error']
+                    when 'runtime' then JMESPath::Errors::RuntimeError
                     when 'syntax' then JMESPath::Errors::SyntaxError
                     when 'unknown-function' then JMESPath::Errors::UnknownFunctionError
                     else raise "unhandled error type #{test_case['error']}"

--- a/spec/compliance_without_errors_spec.rb
+++ b/spec/compliance_without_errors_spec.rb
@@ -1,0 +1,54 @@
+require 'simplecov'
+require 'jmespath'
+require 'rspec'
+
+SimpleCov.command_name('test:compliance')
+
+describe 'Compliance' do
+  PARSER = JMESPath::Parser.new(:disable_visit_errors => true)
+  Dir.glob('spec/compliance/*.json').each do |path|
+    describe(File.basename(path).split('.').first) do
+      JMESPath.load_json(path).each do |scenario|
+        describe("Given #{scenario['given'].inspect}") do
+          scenario['cases'].each do |test_case|
+
+            if test_case['error']
+
+              if %w[invalid-type invalid-arity runtime].include?(test_case['error'])
+                it "the expression #{test_case['expression'].inspect} returns nil if disable_visit_errors is true" do
+                  
+                  result = PARSER.parse(test_case['expression']).visit(scenario['given'])
+                  expect(result).to be_nil
+                end
+              else
+                it "the expression #{test_case['expression'].inspect} raises a #{test_case['error']} error when parsing even if disable_visit_errors is true" do
+
+                  error_class = case test_case['error']
+                    when 'syntax' then JMESPath::Errors::SyntaxError
+                    when 'unknown-function' then JMESPath::Errors::UnknownFunctionError
+                    else raise "unhandled error type #{test_case['error']}"
+                  end
+
+                  raised = nil
+                  begin
+                    PARSER.parse(test_case['expression'])
+                  rescue JMESPath::Errors::Error => error
+                    raised = error
+                  end
+
+                  expect(raised).to be_kind_of(error_class)
+                end
+              end
+            else
+              it "searching #{test_case['expression'].inspect} returns #{test_case['result'].inspect}" do
+                result = PARSER.parse(test_case['expression']).visit(scenario['given'])
+                expect(result).to eq(test_case['result'])
+              end
+
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/compliance_without_errors_spec.rb
+++ b/spec/compliance_without_errors_spec.rb
@@ -24,7 +24,7 @@ describe 'Compliance' do
                 it "the expression #{test_case['expression'].inspect} raises a #{test_case['error']} error when parsing even if disable_visit_errors is true" do
 
                   error_class = case test_case['error']
-                    when 'runtime' then JMESPath::Errors::RuntimeError
+                    when 'invalid-value' then JMESPath::Errors::InvalidValueError
                     when 'syntax' then JMESPath::Errors::SyntaxError
                     when 'unknown-function' then JMESPath::Errors::UnknownFunctionError
                     else raise "unhandled error type #{test_case['error']}"


### PR DESCRIPTION
This pull request adds the Parser option `disable_visit_errors`, which will disable raising of errors during runtime. Errors during expression parsing will still happen though.
