### PR TITLE
Fix OR expressions with true on the left hand side

### DIFF
--- a/lib/jmespath/nodes/or.rb
+++ b/lib/jmespath/nodes/or.rb
@@ -9,7 +9,7 @@ module JMESPath
 
       def visit(value)
         result = @left.visit(value)
-        if result.nil? or result.empty?
+        if result == false || result.nil? || (result.respond_to?(:empty?) && result.empty?)
           @right.visit(value)
         else
           result

--- a/spec/compliance/ormatch.json
+++ b/spec/compliance/ormatch.json
@@ -1,6 +1,6 @@
 [{
     "given":
-        {"outer": {"foo": "foo", "bar": "bar", "baz": "baz"}},
+        {"outer": {"foo": "foo", "bar": "bar", "baz": "baz"}, "primitives": {"t": true, "f": false, "n": null}},
      "cases": [
          {
             "expression": "outer.foo || outer.bar",
@@ -41,6 +41,18 @@
          {
             "expression": "outer.bad||outer.alsobad",
             "result": null
+         },
+         {
+            "expression": "primitives.t || outer.foo",
+            "result": true
+         },
+         {
+            "expression": "primitives.f || outer.foo",
+            "result": "foo"
+         },
+         {
+            "expression": "primitives.n || outer.foo",
+            "result": "foo"
          }
      ]
 }]


### PR DESCRIPTION
This fixes a bug where `foo || bar` where `foo` is true fails with `NoMethodError: undefined method`empty?' for true:TrueClass`.
