### PR TITLE
Add AND, NOT and paren expressions

### DIFF
--- a/lib/jmespath/lexer.rb
+++ b/lib/jmespath/lexer.rb
@@ -16,6 +16,7 @@ module JMESPath
       '\*'                         => :star,
       '\[\]'                       => :flatten,
       '-?\d+'                      => :number,
+      '&&'                         => :and,
       '\|\|'                       => :or,
       '\|'                         => :pipe,
       '\[\?'                       => :filter,

--- a/lib/jmespath/lexer.rb
+++ b/lib/jmespath/lexer.rb
@@ -39,6 +39,7 @@ module JMESPath
       '<'                          => :comparator,
       '>'                          => :comparator,
       '[ \t]'                      => :skip,
+      '!'                          => :not,
     }.each.with_index do |(pattern, type), n|
       TOKEN_PATTERNS[n] = pattern
       TOKEN_TYPES[n] = type

--- a/lib/jmespath/nodes.rb
+++ b/lib/jmespath/nodes.rb
@@ -18,6 +18,7 @@ module JMESPath
       end
     end
 
+    autoload :And, 'jmespath/nodes/and'
     autoload :Comparator, 'jmespath/nodes/comparator'
     autoload :Condition, 'jmespath/nodes/condition'
     autoload :Current, 'jmespath/nodes/current'

--- a/lib/jmespath/nodes.rb
+++ b/lib/jmespath/nodes.rb
@@ -30,6 +30,7 @@ module JMESPath
     autoload :Literal, 'jmespath/nodes/literal'
     autoload :MultiSelectHash, 'jmespath/nodes/multi_select_hash'
     autoload :MultiSelectList, 'jmespath/nodes/multi_select_list'
+    autoload :Not, 'jmespath/nodes/not'
     autoload :Or, 'jmespath/nodes/or'
     autoload :Pipe, 'jmespath/nodes/pipe'
     autoload :Projection, 'jmespath/nodes/projection'

--- a/lib/jmespath/nodes/and.rb
+++ b/lib/jmespath/nodes/and.rb
@@ -1,0 +1,22 @@
+module JMESPath
+  # @api private
+  module Nodes
+    class And < Node
+      def initialize(left, right)
+        @left = left
+        @right = right
+      end
+
+      def visit(value)
+        result = @left.visit(value)
+        if result && (!result.respond_to?(:empty?) || !result.empty?)
+          @right.visit(value)
+        end
+      end
+
+      def optimize
+        self.class.new(@left.optimize, @right.optimize)
+      end
+    end
+  end
+end

--- a/lib/jmespath/nodes/not.rb
+++ b/lib/jmespath/nodes/not.rb
@@ -1,0 +1,14 @@
+module JMESPath
+  # @api private
+  module Nodes
+    class Not < Node
+      def initialize(expression)
+        @expression = expression
+      end
+
+      def visit(value)
+        !@expression.visit(value)
+      end
+    end
+  end
+end

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -75,6 +75,11 @@ module JMESPath
       Nodes::Expression.new(expr(stream, 2))
     end
 
+    def nud_not(stream)
+      stream.next
+      Nodes::Not.new(expr(stream, 0))
+    end
+
     def nud_filter(stream)
       led_filter(stream, CURRENT_NODE)
     end

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -36,8 +36,8 @@ module JMESPath
 
     # @api private
     def method_missing(method_name, *args)
-      if matches = method_name.match(/^(nud_|led_)(.*)/)
-        raise Errors::SyntaxError, "unexpected token #{matches[2]}"
+      if matches = method_name.to_s.match(/^(nud_|led_)(.*)/)
+        raise Errors::SyntaxError, "unexpected token: #{matches[2]}"
       else
         super
       end

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -198,6 +198,12 @@ module JMESPath
       Nodes::Or.new(left, right)
     end
 
+    def led_and(stream, left)
+      stream.next
+      right = expr(stream, Token::BINDING_POWER[:and])
+      Nodes::And.new(left, right)
+    end
+
     def led_pipe(stream, left)
       stream.next
       right = expr(stream, Token::BINDING_POWER[:pipe])

--- a/lib/jmespath/parser.rb
+++ b/lib/jmespath/parser.rb
@@ -60,6 +60,16 @@ module JMESPath
       CURRENT_NODE
     end
 
+    def nud_lparen(stream)
+      stream.next
+      expr = expr(stream, 0)
+      unless stream.token.type == :rparen
+        raise Errors::SyntaxError, "expected token rparen, got #{stream.token.type}"
+      end
+      stream.next
+      expr
+    end
+
     def nud_expref(stream)
       stream.next
       Nodes::Expression.new(expr(stream, 2))

--- a/lib/jmespath/token.rb
+++ b/lib/jmespath/token.rb
@@ -21,6 +21,7 @@ module JMESPath
       :pipe              => 1,
       :comparator        => 2,
       :or                => 5,
+      :and               => 5,
       :flatten           => 6,
       :star              => 20,
       :dot               => 40,

--- a/spec/compliance/andmatch.json
+++ b/spec/compliance/andmatch.json
@@ -1,0 +1,58 @@
+[{
+    "given":
+        {"outer": {"foo": "foo", "bar": "bar", "baz": "baz"}, "primitives": {"t": true, "f": false, "n": null}},
+     "cases": [
+         {
+            "expression": "outer.foo && outer.bar",
+            "result": "bar"
+         },
+         {
+            "expression": "outer.foo&&outer.bar",
+            "result": "bar"
+         },
+         {
+            "expression": "outer.bar && outer.baz",
+            "result": "baz"
+         },
+         {
+            "expression": "outer.bar&&outer.baz",
+            "result": "baz"
+         },
+         {
+            "expression": "outer.bad && outer.foo",
+            "result": null
+         },
+         {
+            "expression": "outer.bad&&outer.foo",
+            "result": null
+         },
+         {
+            "expression": "outer.foo && outer.bad",
+            "result": null
+         },
+         {
+            "expression": "outer.foo&&outer.bad",
+            "result": null
+         },
+         {
+            "expression": "outer.bad && outer.alsobad",
+            "result": null
+         },
+         {
+            "expression": "outer.bad&&outer.alsobad",
+            "result": null
+         },
+         {
+            "expression": "outer.foo && primitives.t",
+            "result": true
+         },
+         {
+            "expression": "outer.foo && primitives.f",
+            "result": false
+         },
+         {
+            "expression": "outer.foo && primitives.n",
+            "result": null
+         }
+     ]
+}]

--- a/spec/compliance/not.json
+++ b/spec/compliance/not.json
@@ -1,0 +1,30 @@
+[{
+    "given":
+         {"t": true, "f": false, "n": null, "s": "string"},
+     "cases": [
+         {
+            "expression": "!t",
+            "result": false
+         },
+         {
+            "expression": "!f",
+            "result": true
+         },
+         {
+            "expression": "!`true`",
+            "result": false
+         },
+         {
+            "expression": "!`false`",
+            "result": true
+         },
+         {
+            "expression": "!n",
+            "result": true
+         },
+         {
+            "expression": "!s",
+            "result": false
+         }
+     ]
+}]

--- a/spec/compliance/paren_expressions.json
+++ b/spec/compliance/paren_expressions.json
@@ -1,0 +1,32 @@
+[{
+  "given": {
+    "foo": "foo",
+    "bar": "bar"
+  },
+  "cases": [
+    {
+      "expression": "(foo)",
+      "result": "foo"
+    },
+    {
+      "expression": "(bar)",
+      "result": "bar"
+    },
+    {
+      "expression": "((foo))",
+      "result": "foo"
+    },
+    {
+      "expression": "(invalid)",
+      "result": null
+    },
+    {
+      "expression": "(foo",
+      "error": "syntax"
+    },
+    {
+      "expression": "foo)",
+      "error": "syntax"
+    }
+  ]
+}]


### PR DESCRIPTION
Extend implementation to support `AND`, `NOT` and paren expressions, according to the JMESPath specification.

Left to do is to verify correct precedence of AND vs OR and other expressions by adding another test case. Also, I'm not sure if the binding power for `lparen` should be adjusted, or if parsing paren expressions with right binding power 0 is the correct thing to do. Any ideas for additional test cases regarding these things are welcome.
